### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,17 +62,6 @@
         <javac.src.version>1.6</javac.src.version>
         <javac.target.version>1.6</javac.target.version>
         <!-- Configuration properties for the OSGi maven-bundle-plugin -->
-        <osgi.import>com.fasterxml.jackson.core
-            ,com.fasterxml.jackson.core.util
-            ,com.fasterxml.jackson.databind
-            ,com.fasterxml.jackson.databind.deser.std
-            ,com.fasterxml.jackson.databind.jsontype
-            ,com.fasterxml.jackson.databind.module
-            ,com.fasterxml.jackson.databind.node
-            ,com.fasterxml.jackson.databind.ser.std
-            ,org.threeten.bp
-            ,org.threeten.bp.temporal
-        </osgi.import>
         <osgi.export>com.fasterxml.jackson.datatype.threetenbp.*;version=${project.version}</osgi.export>
         <threetenbp.version>1.2</threetenbp.version>
     </properties>


### PR DESCRIPTION
Registering the ThreeTenModule in OSGi throws ClassNotFoundException's (jackson-datatype-threetenbp version 2.5.0 and jackson version 2.5.4). The Import-Packages should be generated automatically from needed dependencies. 